### PR TITLE
Update clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ uploading to check if the file was properly stored.
 
 It's made for deployment on Heroku:
 
-* `git clone git://github.com:mattmatt/s3itch.git`
+* `git clone git://github.com/mattmatt/s3itch.git`
 * `heroku create --stack cedar`
 * `git push heroku master`
 * Set environment variables `AWS_REGION` (e.g. eu-west-1), `AWS_ACCESS_KEY_ID`,


### PR DESCRIPTION
I ran into a problem cloning the repo, so I updated the README

$ git clone git://github.com:mattmatt/s3itch.git
Cloning into s3itch...
fatal: Unable to look up github.com (port mattmatt) (nodename nor servname provided, or not known)

This also seems to work:

$ git clone git@github.com:mattmatt/s3itch.git

Looking forward to hosting my own images. Thanks!
