### PR TITLE
Fixes the question mark bug

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -22,7 +22,7 @@ class S3itchApp < Sinatra::Base
     begin
       # Skitch does not encode question marks, so we have to recombine the
       # name here if necessary
-      name = if request.query_string
+      name = if request.query_string && !request.query_string.empty?
         "#{params[:name]}?#{request.query_string}"
       else
         params[:name]

--- a/app.rb
+++ b/app.rb
@@ -20,7 +20,14 @@ class S3itchApp < Sinatra::Base
   put '/:name' do
     retries = 0
     begin
-      content_type = MIME::Types.type_for(params[:name]).first.content_type
+      # Skitch does not encode question marks, so we have to recombine the
+      # name here if necessary
+      name = if request.query_string
+        "#{params[:name]}?#{request.query_string}"
+      else
+        params[:name]
+      end
+      content_type = MIME::Types.type_for(name).first.content_type
       file = bucket.files.create(key: params[:name], public: true, body: request.body.read, content_type: content_type)
       puts "Uploaded file #{params[:name]} to S3"
       redirect "http://#{ENV['S3_BUCKET']}/#{params[:name]}", 201


### PR DESCRIPTION
**Reopens issue #7 with cleaner commits.**

For example, when I tried to upload a screenshot titled `foo?bar`:

![Webpost error](http://shots.matiaskorhonen.fi/Webpost_error-20120929-180617.png)

And the logs (private information removed/scrambled):

```
* Connected to mys3itch.herokuapp.com (50.19.85.62) port 80 (#0)
* Server auth using Basic with user 's3itch'
> PUT /foo?bar-20120929-180436.png HTTP/1.1
Authorization: Basic 9ce6d4060c8791a9cf2f17596f31aa2782f8faea74ff1dfdb76cae4938==
Host: mys3itch.herokuapp.com
Accept: */*
Content-Length: 7488
Expect: 100-continue

< HTTP/1.1 100 Continue
< HTTP/1.1 500 Internal Server Error
< Content-Type: text/html;charset=utf-8
< Server: thin 1.3.1 codename Triple Espresso
< X-Frame-Options: sameorigin
< X-Xss-Protection: 1; mode=block
< Content-Length: 0
< Connection: keep-alive
< 
* Connection #0 to host mys3itch.herokuapp.com left intact
* Closing connection #0
```
