### PR TITLE
Erroneous image URL with TweetBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source :rubygems
 
 gem 'sinatra'
-gem 'fog'
+gem 'fog', '~> 1.6.0'
 gem 'thin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    builder (3.0.0)
+    builder (3.1.4)
     daemons (1.1.8)
     eventmachine (0.12.10)
-    excon (0.13.2)
-    fog (1.3.1)
+    excon (0.16.7)
+    fog (1.6.0)
       builder
-      excon (~> 0.13.0)
+      excon (~> 0.14)
       formatador (~> 0.2.0)
       mime-types
       multi_json (~> 1.0)
@@ -15,13 +15,13 @@ GEM
       net-ssh (>= 2.1.3)
       nokogiri (~> 1.5.0)
       ruby-hmac
-    formatador (0.2.1)
-    mime-types (1.18)
-    multi_json (1.2.0)
+    formatador (0.2.3)
+    mime-types (1.19)
+    multi_json (1.3.6)
     net-scp (1.0.4)
       net-ssh (>= 1.99.1)
-    net-ssh (2.3.0)
-    nokogiri (1.5.2)
+    net-ssh (2.6.1)
+    nokogiri (1.5.5)
     rack (1.4.1)
     rack-protection (1.2.0)
       rack
@@ -40,6 +40,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fog
+  fog (~> 1.6.0)
   sinatra
   thin

--- a/app.rb
+++ b/app.rb
@@ -35,7 +35,8 @@ class S3itchApp < Sinatra::Base
         content_type: content_type,
         metadata: { "Cache-Control" => 'public, max-age=315360000'}
       })
-      return "<mediaurl>http://#{file.public_url}</mediaurl>"
+      puts "Uploaded file #{file.key} to S3"
+      return "<mediaurl>http://#{ENV['S3_BUCKET']}/#{file.key}</mediaurl>"
     rescue => e
       puts "Error uploading file #{media[:name]} to S3: #{e.message}"
       if e.message =~ /Broken pipe/ && retries < 5


### PR DESCRIPTION
Sharing an image via the new TweetBot endpoint gave me this tweet (and the URL in it):

<blockquote class="twitter-tweet"><p>Testing my custom image upload endpoint http://<a href="https://t.co/xasp4IlH" title="https://s3.amazonaws.com/shots.matiaskorhonen.fi/tweetbot%2F1tqoJ7.png">s3.amazonaws.com/shots.matiasko…</a></p>&mdash; Matias Korhonen (@matiaskorhonen) <a href="https://twitter.com/matiaskorhonen/status/260479640655777793" data-datetime="2012-10-22T20:36:00+00:00">October 22, 2012</a></blockquote>


Following the link yields this error:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<Error>
  <Code>PermanentRedirect</Code>
  <Message>The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.</Message>
  <RequestId>9AFB207E29601E0D</RequestId>
  <Bucket>shots.matiaskorhonen.fi</Bucket>
  <HostId>0G8h9h4yIq/vkaMrIiCMM0VqpW1sntpkqrcm3Lp4MqZhbBxInmDfUOiEc/R+J5el</HostId>
  <Endpoint>shots.matiaskorhonen.fi.s3.amazonaws.com</Endpoint>
</Error>
```

Sharing from Skitch still seems to work just fine.
