### PR TITLE
Fix broken tweetbot with CNAMEs and provide non-CNAME option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Installation
 The app assumes you're storing files in a bucket that has a CNAME attached to
 it, e.g. s3itch.mydomain.com, and that you're setting this CNAME as base URL in
 Skitch. Skitch sends a HEAD request to the base URL (your S3 bucket) after
-uploading to check if the file was properly stored.
+uploading to check if the file was properly stored. The CNAME isn't, however, required
+and can be disabled.
 
 It's made for deployment on Heroku:
 
@@ -25,11 +26,16 @@ It's made for deployment on Heroku:
 * `git push heroku master`
 * Set environment variables `AWS_REGION` (e.g. eu-west-1), `AWS_ACCESS_KEY_ID`,
   `AWS_SECRET_ACCESS_KEY`, `S3_BUCKET`, `HTTP_USER` and `HTTP_PASS` for the Heroku app
+* If you wish to NOT use a CNAME, also set `NO_CNAME` to `true`
 * Configure Skitch with the bucket and the URL of the Heroku app. Also configure the
   username and password if set.: ![Skitch Configuration](http://s3itch.paperplanes.de/Preferences-20120401-174030.png)
 
   By the way, this picture was uploaded using this bridge and is hosted on S3.
   Did that just blow your mind?
+
+If you are not using a CNAME, set the base URL above like so:
+
+`http://<bucketname>.s3.amazonaws.com`
 
 Using
 =====

--- a/app.rb
+++ b/app.rb
@@ -35,7 +35,11 @@ class S3itchApp < Sinatra::Base
         content_type: content_type,
         metadata: { "Cache-Control" => 'public, max-age=315360000'}
       })
-      return "<mediaurl>http://#{file.public_url}</mediaurl>"
+      if ENV['NO_CNAME']
+        return "<mediaurl>#{file.public_url}</mediaurl>"
+      else
+        return "<mediaurl>#{ENV['S3_BUCKET']}/#{file.key}</mediaurl>"
+      end
     rescue => e
       puts "Error uploading file #{media[:name]} to S3: #{e.message}"
       if e.message =~ /Broken pipe/ && retries < 5
@@ -69,7 +73,11 @@ class S3itchApp < Sinatra::Base
         metadata: { "Cache-Control" => 'public, max-age=315360000'}
       })
       puts "Uploaded file #{params[:name]} to S3"
-      redirect "#{file.public_url}", 201
+      if ENV['NO_CNAME']
+        redirect "#{file.public_url}", 201
+      else
+        redirect "#{ENV['S3_BUCKET']}/#{file.key}", 201
+      end
     rescue => e
       puts "Error uploading file #{params[:name]} to S3: #{e.message}"
       if e.message =~ /Broken pipe/ && retries < 5


### PR DESCRIPTION
This should resolve ticket #12 in a way that I think provides the most flexibility. It keeps the original behavior but provides an additional env var to disable CNAME (`NO_CNAME=true`) usage. I've tested this with and without CNAMES for both Tweetbot AND Skitch:
- Skitch without CNAME - http://s3itch.s3.amazonaws.com/Screen_Shot_2012-10-22_at_10.42.06_PM-20121022-225456.jpg
- Skitch with CNAME - http://s3itch.lusis.org/Screen_Shot_2012-10-22_at_10.42.06_PM-20121022-231510.jpg
- Tweetbot without CNAME - http://s3itch.s3.amazonaws.com/tweetbot/1tquEu.jpg
- Tweetbot with CNAME - http://s3itch.lusis.org/tweetbot/1tquzx.jpg
