### PR TITLE
Require 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source :rubygems
 
+ruby '1.9.3'
+
 gem 'sinatra'
 gem 'fog'
 gem 'thin'


### PR DESCRIPTION
According to Heroku, Ruby 1.9.2 has been "de-facto discontinued", so let's use 1.9.3 as a minimum.
